### PR TITLE
Added the UI for displaying amendment requests with unit tests

### DIFF
--- a/src/server/applications/amend.njk
+++ b/src/server/applications/amend.njk
@@ -1,0 +1,22 @@
+{% extends 'layouts/page.njk' %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block content %}
+  {{ appHeading({
+    text: heading,
+    caption: "Marine Licensing Alpha"
+  }) }}
+
+  {% call appPageBody() %}
+    <p class="govuk-body-l">These are the details as submitted by the applicant.</p>
+
+    {{ govukErrorSummary({
+      titleText: "Your case worker has identified some issues with your application. Please review below for specific information."
+    }) }}
+
+    {% include 'partials/application.njk' %}
+  {% endcall %}
+{% endblock %}

--- a/src/server/applications/controller.js
+++ b/src/server/applications/controller.js
@@ -16,19 +16,45 @@ export const getApplication = {
       params: { prefix, year, sequenceNumber }
     } = request
 
-    const { payload } = await Wreck.get(
+    const { payload: applicationJson } = await Wreck.get(
       `${config.get('backendApiUrl')}/applications/${prefix}/${year}/${sequenceNumber}`
     )
-
-    const application = JSON.parse(payload).value
-    const heading = `Application ${prefix}/${year}/${sequenceNumber}`
+    const application = JSON.parse(applicationJson).value
 
     return h.view('applications/index', {
-      pageTitle: heading,
-      heading,
+      pageTitle: `Application ${prefix}/${year}/${sequenceNumber}`,
+      heading: `Application ${prefix}/${year}/${sequenceNumber}`,
       breadcrumbs,
       application,
       formDisabled: true
+    })
+  }
+}
+
+export const getApplicationAmendment = {
+  method: 'GET',
+  path: '/applications/{prefix}/{year}/{sequenceNumber}/amend',
+  handler: async (request, h) => {
+    const {
+      params: { prefix, year, sequenceNumber }
+    } = request
+
+    const { payload: applicationJson } = await Wreck.get(
+      `${config.get('backendApiUrl')}/applications/${prefix}/${year}/${sequenceNumber}`
+    )
+    const { value: application } = JSON.parse(applicationJson)
+
+    const { payload: amendmentJson } = await Wreck.get(
+      `${config.get('backendApiUrl')}/applications/${prefix}/${year}/${sequenceNumber}/amendment-request`
+    )
+    const { value: amendment } = JSON.parse(amendmentJson)
+
+    return h.view('applications/amend', {
+      pageTitle: `Application ${prefix}/${year}/${sequenceNumber}`,
+      heading: `Application ${prefix}/${year}/${sequenceNumber}`,
+      breadcrumbs,
+      application,
+      amendment
     })
   }
 }

--- a/src/server/applications/index.js
+++ b/src/server/applications/index.js
@@ -1,10 +1,13 @@
-import { getApplication } from '~/src/server/applications/controller'
+import {
+  getApplication,
+  getApplicationAmendment
+} from '~/src/server/applications/controller'
 
 const applications = {
   plugin: {
     name: 'applications',
     register: async (server) => {
-      server.route([getApplication])
+      server.route([getApplication, getApplicationAmendment])
     }
   }
 }

--- a/src/server/common/templates/partials/application.njk
+++ b/src/server/common/templates/partials/application.njk
@@ -12,7 +12,10 @@
     id: "title",
     name: "title",
     value: application.title,
-    disabled: formDisabled
+    disabled: formDisabled,
+    errorMessage: {
+      text: amendment.title.comment
+    } if amendment.title.comment
   }) }}
 
   {{ govukTextarea({
@@ -25,7 +28,10 @@
       text: "Include details of what the project will involve and what it aims to achieve"
     },
     value: application.background,
-    disabled: formDisabled
+    disabled: formDisabled,
+    errorMessage: {
+      text: amendment.background.comment
+    } if amendment.background.comment
   }) }}
 
   {{ govukTextarea({
@@ -38,7 +44,10 @@
       text: "Provide the coordinates that define the boundaries of your project"
     },
     value: application.site.coordinates,
-    disabled: formDisabled
+    disabled: formDisabled,
+    errorMessage: {
+      text: amendment.site.coordinates.comment
+    } if amendment.site.coordinates.comment
   }) }}
 
   {% call govukFieldset({
@@ -56,7 +65,10 @@
       name: "firstName",
       autocomplete: "given-name",
       value: application.applicant.firstName,
-      disabled: formDisabled
+      disabled: formDisabled,
+      errorMessage: {
+        text: amendment.applicant.firstName.comment
+      } if amendment.applicant.firstName.comment
     }) }}
 
     {{ govukInput({
@@ -67,7 +79,10 @@
       name: "lastName",
       autocomplete: "family-name",
       value: application.applicant.lastName,
-      disabled: formDisabled
+      disabled: formDisabled,
+      errorMessage: {
+        text: amendment.applicant.lastName.comment
+      } if amendment.applicant.lastName.comment
     }) }}
 
     {{ govukInput({
@@ -78,7 +93,10 @@
       name: "address",
       autocomplete: "address",
       value: application.applicant.address,
-      disabled: formDisabled
+      disabled: formDisabled,
+      errorMessage: {
+        text: amendment.applicant.address.comment
+      } if amendment.applicant.address.comment
     }) }}
     {% from "govuk/components/input/macro.njk" import govukInput %}
 
@@ -95,8 +113,10 @@
       autocomplete: "email",
       spellcheck: false,
       value: application.applicant.email,
-      disabled: formDisabled
-
+      disabled: formDisabled,
+      errorMessage: {
+        text: amendment.applicant.email.comment
+      } if amendment.applicant.email.comment
     }) }}
   {% endcall %}
 

--- a/src/server/common/templates/partials/application.test.js
+++ b/src/server/common/templates/partials/application.test.js
@@ -1,0 +1,90 @@
+import { renderTemplate } from '~/test-helpers/component-helpers'
+
+describe('partials/application', () => {
+  const application = {
+    title: 'Fake Application',
+    background: 'Fake application background',
+    applicant: {
+      firstName: 'Joe',
+      lastName: 'Bloggs',
+      email: 'joe.bloggs@domain.com',
+      address: '1 Somewhere Street, Somewhere, AB1 2CD'
+    },
+    site: {
+      coordinates: '[1, 1]'
+    }
+  }
+
+  describe('rendering an application', () => {
+    test('should render template correctly using the application details', () => {
+      const template = renderTemplate('partials/application.njk', {
+        application
+      }).root()
+
+      expect(template.find('[name="title"]').val()).toEqual(application.title)
+      expect(template.find('[name="background"]').text()).toEqual(
+        application.background
+      )
+      expect(template.find('[name="firstName"]').val()).toEqual(
+        application.applicant.firstName
+      )
+      expect(template.find('[name="lastName"]').val()).toEqual(
+        application.applicant.lastName
+      )
+      expect(template.find('[name="email"]').val()).toEqual(
+        application.applicant.email
+      )
+      expect(template.find('[name="address"]').val()).toEqual(
+        application.applicant.address
+      )
+      expect(template.find('[name="site"]').val()).toEqual(
+        application.site.coordinates
+      )
+    })
+  })
+
+  describe('rendering an amendment', () => {
+    const amendment = {
+      applicant: {
+        firstName: {
+          originalValue: application.applicant.firstName,
+          comment: 'This looks like a fake name'
+        }
+      },
+      site: {
+        coordinates: {
+          originalValue: application.site.coordinates,
+          comment: 'These look like fake coordinates'
+        }
+      }
+    }
+
+    test('should render template with the correct header', () => {
+      const template = renderTemplate('partials/application.njk', {
+        application,
+        amendment
+      }).root()
+
+      expect(template.find('.govuk-error-summary')).not.toBeNull()
+    })
+
+    test('should render template correctly using the amendment details', () => {
+      const template = renderTemplate('partials/application.njk', {
+        application,
+        amendment
+      }).root()
+
+      const applicantParent = template.find('[name="firstName"]').parent()
+      expect(applicantParent.find('.govuk-input--error')).not.toBeNull()
+      expect(applicantParent.find('.govuk-error-message').text()).toContain(
+        amendment.applicant.firstName.comment
+      )
+
+      const siteParent = template.find('[name="site"]').parent()
+      expect(siteParent.find('.govuk-input--error')).not.toBeNull()
+      expect(siteParent.find('.govuk-error-message').text()).toContain(
+        amendment.site.coordinates.comment
+      )
+    })
+  })
+})

--- a/test-helpers/component-helpers.js
+++ b/test-helpers/component-helpers.js
@@ -46,4 +46,10 @@ function renderComponent(componentName, params, callBlock) {
   return load(nunjucksTestEnv.renderString(macroString))
 }
 
-export { renderComponent }
+function renderTemplate(templateName, params) {
+  const template = nunjucksTestEnv.render(templateName, params)
+
+  return load(template)
+}
+
+export { renderComponent, renderTemplate }


### PR DESCRIPTION
This PR contains changes to the application partial template so that if an amendment request is present along with the application, then additional [error] elements are displayed to explain to an applicant what and why is wrong.